### PR TITLE
`Sanity.query_to_query_params/3`

### DIFF
--- a/lib/sanity.ex
+++ b/lib/sanity.ex
@@ -116,6 +116,22 @@ defmodule Sanity do
   defp _list_references(%{} = map), do: Map.values(map) |> _list_references()
   defp _list_references(_), do: []
 
+  @spec listen(String.t(), keyword() | map(), keyword() | map()) :: Request.t()
+  def listen(query, variables \\ %{}, query_params \\ []) do
+    query_params =
+      variables
+      |> stringify_keys()
+      |> Enum.map(fn {k, v} -> {"$#{k}", Jason.encode!(v)} end)
+      |> Enum.into(camelize_params(query_params))
+      |> Map.put("query", query)
+
+    %Request{
+      endpoint: :listen,
+      method: :get,
+      query_params: query_params
+    }
+  end
+
   @doc """
   Generates a request for the [Mutate](https://www.sanity.io/docs/http-mutations) endpoint.
 
@@ -151,18 +167,20 @@ defmodule Sanity do
   """
   @spec query(String.t(), keyword() | map(), keyword() | map()) :: Request.t()
   def query(query, variables \\ %{}, query_params \\ []) do
-    query_params =
-      variables
-      |> stringify_keys()
-      |> Enum.map(fn {k, v} -> {"$#{k}", Jason.encode!(v)} end)
-      |> Enum.into(camelize_params(query_params))
-      |> Map.put("query", query)
-
     %Request{
       endpoint: :query,
       method: :get,
-      query_params: query_params
+      query_params: query_to_query_params(query, variables, query_params)
     }
+  end
+
+  @doc false
+  def query_to_query_params(query, variables, query_params) do
+    variables
+    |> stringify_keys()
+    |> Enum.map(fn {k, v} -> {"$#{k}", Jason.encode!(v)} end)
+    |> Enum.into(camelize_params(query_params))
+    |> Map.put("query", query)
   end
 
   @doc """

--- a/lib/sanity.ex
+++ b/lib/sanity.ex
@@ -116,22 +116,6 @@ defmodule Sanity do
   defp _list_references(%{} = map), do: Map.values(map) |> _list_references()
   defp _list_references(_), do: []
 
-  @spec listen(String.t(), keyword() | map(), keyword() | map()) :: Request.t()
-  def listen(query, variables \\ %{}, query_params \\ []) do
-    query_params =
-      variables
-      |> stringify_keys()
-      |> Enum.map(fn {k, v} -> {"$#{k}", Jason.encode!(v)} end)
-      |> Enum.into(camelize_params(query_params))
-      |> Map.put("query", query)
-
-    %Request{
-      endpoint: :listen,
-      method: :get,
-      query_params: query_params
-    }
-  end
-
   @doc """
   Generates a request for the [Mutate](https://www.sanity.io/docs/http-mutations) endpoint.
 

--- a/lib/sanity.ex
+++ b/lib/sanity.ex
@@ -174,6 +174,7 @@ defmodule Sanity do
     }
   end
 
+  # Useful when implementing listen. See https://github.com/balexand/sanity/pull/74.
   @doc false
   def query_to_query_params(query, variables, query_params) do
     variables


### PR DESCRIPTION
Useful for implementing listen. See #74.